### PR TITLE
ci: add Copilot bot login to auto-approve allowlist

### DIFF
--- a/.github/workflows/auto-approve-bots.yml
+++ b/.github/workflows/auto-approve-bots.yml
@@ -15,6 +15,7 @@ jobs:
       github.event.pull_request.user.login == 'dependabot[bot]' ||
       github.event.pull_request.user.login == 'copilot-swe-agent[bot]' ||
       github.event.pull_request.user.login == 'app/copilot-swe-agent' ||
+      github.event.pull_request.user.login == 'Copilot' ||
       github.event.pull_request.user.login == 'github-actions[bot]'
     steps:
       - name: Approve PR
@@ -30,7 +31,7 @@ jobs:
           # webhook payload (GitHub-controlled, not user input), but we treat
           # it as untrusted and never interpolate it into a command string.
           case "$PR_AUTHOR" in
-            dependabot\[bot\]|copilot-swe-agent\[bot\]|github-actions\[bot\]) ;;
+            dependabot\[bot\]|copilot-swe-agent\[bot\]|Copilot|github-actions\[bot\]) ;;
             *)
               echo "Refusing to approve: author '$PR_AUTHOR' not on allowlist" >&2
               exit 1


### PR DESCRIPTION
The new Copilot SWE agent authors PRs as login `Copilot` (id 198982749) instead of the legacy `copilot-swe-agent[bot]`. The job-level `if:` gate in `auto-approve-bots.yml` was skipping these, leaving Copilot PRs stuck at `REVIEW_REQUIRED` on branch-protected branches.

Adds `Copilot` to:
- Workflow `if:` gate
- Defense-in-depth shell case allowlist

Verified against PRs #40-45 (all show `user.login == "Copilot"`). Will be admin-merged to bootstrap; future Copilot PRs will auto-approve normally.