### PR TITLE
chore(agents): make security-review agent aware of CodeQL + Dependabot

### DIFF
--- a/.github/agents/.sync-overrides
+++ b/.github/agents/.sync-overrides
@@ -1,0 +1,9 @@
+# Agents in this list are NOT overwritten by ~/.copilot/skills/sync-agent-roster.
+# Use sparingly — only when the per-repo divergence is intentional and documented.
+
+# security-review: this repo has CodeQL default setup gating BP, so the agent is
+# tuned to skip OWASP categories CodeQL covers and focus on what CodeQL can't see
+# (business-logic flaws, auth-flow timing, info leak via 409s/logs). The upstream
+# agent in ~/.copilot/agents/ doesn't assume CodeQL exists because most repos in
+# the roster are private (CodeQL is paid for private). Do not re-sync this one.
+security-review

--- a/.github/agents/MANIFEST.md
+++ b/.github/agents/MANIFEST.md
@@ -29,3 +29,13 @@ as they are not relevant to the game-club stack:
 
 - `telemetry-expert.agent.md` — Forza UDP packet schema, sim physics
 - `race-engineer.agent.md` — Real-world tuning knowledge
+
+## Local Overrides
+
+The following agents intentionally diverge from the upstream
+`~/.copilot/agents/` roster and are excluded from sync (see
+`.sync-overrides`):
+
+- `security-review` — Customized to defer to CodeQL on OWASP A02/A03/A05/A06/A10
+  (CodeQL gates BP on this repo). Refocuses LLM review on business logic,
+  auth flow, info leak — categories CodeQL can't see. Do not re-sync.

--- a/.github/agents/security-review.agent.md
+++ b/.github/agents/security-review.agent.md
@@ -84,15 +84,58 @@ For each finding cite file:line, show the vulnerable snippet and a concrete fix.
 Categories: A01 Access Control, A02 Crypto, A03 Injection, A04 Insecure Design, A05 Misconfig,
 A07 Auth, A08 Integrity, A09 Logging, A10 SSRF.
 
-### gameclub (Next.js 15, TypeScript) focus areas:
-- A01: Route handlers missing `requireAuth()` or `getCurrentUser()` checks
-- A02: Password hashing uses SHA256+salt (not bcrypt) — acceptable for private club, not for public auth
-- A03: `better-sqlite3` raw SQL injection via unparameterized queries
-- A04: Session tokens must be 32-byte hex; check generation entropy
-- A05: RAWG API key exposure in client-side code
-- A07: Cookie `HttpOnly` + `SameSite` flags on session_token
-- A09: No secrets/PII in server logs
-- A10: RAWG API proxy must validate/sanitize external URLs
+### What's already covered by automated tools (DO NOT duplicate)
+
+This repo has **CodeQL default setup** (javascript-typescript + actions) and
+**Dependabot** enabled. They run on every PR + push to main. CodeQL gates the
+branch protection. **Skip these categories — the tools already cover them
+deeper than an LLM review can:**
+
+- **A03 Injection** — `js/sql-injection`, `js/code-injection`, `js/xss`,
+  `js/reflected-xss`, `js/stored-xss`, `js/command-line-injection`
+- **A05 Misconfig (path traversal)** — `js/path-injection`, `js/zipslip`
+- **A06 Vuln dependencies** — Dependabot alerts (don't review `package.json`
+  versions; trust dependabot)
+- **A10 SSRF** — `js/request-forgery`, `js/server-side-request-forgery`
+- **A02 Weak crypto primitives** — `js/weak-cryptographic-algorithm`,
+  `js/insufficient-password-hash` (note: CodeQL doesn't recognize scrypt as a
+  KDF — flag any **CodeQL false-positive dismissal** that doesn't justify why)
+
+If you spot one of the above and CodeQL didn't flag it, do mention it — that's
+a gap worth closing. But do not run a checklist over those categories
+proactively.
+
+### Focus areas LLM review uniquely catches (CodeQL is BLIND here)
+
+- **A01 Access Control logic flaws** — route handler missing
+  `requireAuth()` / `getCurrentUser()`; horizontal privesc (user A reads
+  user B's resource); missing role check on admin endpoints
+- **A04 Insecure Design / business logic** — account lockout enabling DoS;
+  signup invite-code reuse; password change not invalidating sessions;
+  off-by-one in voting/ballot logic; race conditions in election close
+- **A07 Auth flow** — timing oracles in login (verify dummy hash on unknown
+  user); cookie flags (`HttpOnly`, `SameSite`, `Secure`); session token
+  entropy; CSRF protection on mutation endpoints
+- **A09 Logging & info leak** — secrets/PII in server logs; error messages
+  leaking internals (RAWG key in URL, stack traces with paths); 409 responses
+  enabling username/email enumeration
+- **A02 Crypto USE (not primitives)** — wrong constant-time comparison
+  (`===` on tokens), reusing IVs/nonces, missing pepper on hashes,
+  storing reversibly-encrypted passwords, JWT alg=none acceptance
+- **API contract / framework misuse** — CORS wide-open, missing rate-limit
+  on auth, GraphQL introspection on prod, unsafe `dangerouslySetInnerHTML`
+  with computed strings (CodeQL catches obvious cases; LLM catches subtle
+  ones with conditional sanitizers)
+
+### gameclub (Next.js 16, TypeScript, public app) current state
+- Public-facing as of 2026-05-01; Authelia gate removed
+- Auth: scrypt password hashing (N=16384, r=8, p=1), per-account + per-IP
+  login throttle, 12-char min password + banned-list, signup gated by
+  invite code env, `X-Real-Ip` then rightmost-XFF for client IP
+- Session token in `HttpOnly` `Secure` cookie
+- Known open follow-ups: lockout DoS (#54), signup name enumeration (#55),
+  no signup throttle (#56), session-invalidation on password change (#57),
+  RAWG key in error logs (#58)
 
 ## Code Mode: OWASP LLM Top 10
 


### PR DESCRIPTION
Now that CodeQL default setup and Dependabot are gating BP (`Analyze (javascript-typescript)`, `Analyze (actions)` added as required checks), the LLM-based `security-review` agent shouldn't burn tokens duplicating what the static analyzers already cover deeper than an LLM can.

## Changes

- **'What's already covered' section** lists CodeQL rules per OWASP category (A02 weak primitives, A03 injection/XSS, A05 path traversal, A06 deps, A10 SSRF). Agent skips these unless CodeQL missed something.
- **'Focus areas LLM uniquely catches' section** explicitly calls out what CodeQL is blind to: A01 access-control logic flaws, A04 business-logic / lockout-DoS / session-invalidation, A07 auth-flow timing oracles, A09 logging / enumeration via 409s, A02 crypto **use** (vs primitive choice).
- **Refresh stale gameclub focus areas** — was 'SHA256+salt acceptable for private club'; now reflects scrypt + public-facing state + list of open follow-ups #54-#58.
- **Note on CodeQL false-positive**: `js/insufficient-password-hash` rule pack only knows bcrypt/argon2/PBKDF2, flagged scrypt as insufficient (dismissed during initial CodeQL triage).

## Why

Otherwise on every PR we get the same SQL-injection / XSS / SSRF advice from both CodeQL (deep dataflow) and the LLM agent (shallow pattern-match), and the LLM advice is strictly worse for those categories. The LLM's value is in business-logic and design issues — refocus it there.