### PR TITLE
docs: add CONTRIBUTING.md noting fork-PR limitation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,70 @@
+# Contributing
+
+Thanks for your interest in Game Club. This is a small personal project that's
+public for transparency, but day-to-day development happens inside this repo,
+not via fork PRs.
+
+## Reporting issues
+
+Open a GitHub issue. Bugs, feature ideas, and security reports are all welcome.
+For security-sensitive reports, see [SECURITY.md](./SECURITY.md).
+
+## Code contributions
+
+### Fork PRs are not supported end-to-end
+
+The CI/review pipeline relies on workflows that require write access to this
+repository's API:
+
+- `agent-review`, `devops-review`, `security-review`, `tech-writer-review` all
+  publish PR reviews and check-runs via `gh api`.
+- Tech-writer additionally pushes doc-fix commits back to the PR branch.
+
+GitHub policy gives fork-PR workflows a **read-only** `GITHUB_TOKEN` and no
+access to repository secrets. As a result, a PR opened from a fork will sit in
+a broken state: the four required `*-review` checks will fail with 403s, and
+the PR will be unmergeable through the normal flow.
+
+This is a deliberate trade-off (tracked under [issue #73](https://github.com/mac-reichelt/game-club/issues/73)). Mergeable fork PRs
+would require running the review workflows under `pull_request_target`, which
+introduces well-known security risks and significantly more code to manage
+safely.
+
+### Working around the limitation
+
+If you want to contribute a code change:
+
+1. **Open an issue first** describing the change. If we agree on the approach,
+   I'll grant you a feature branch on this repo so the review pipeline runs
+   end-to-end. Push to that branch and open the PR from inside the repo.
+2. **Or**: open the fork PR anyway. I'll cherry-pick the commit(s) onto a
+   branch in this repo, credit you in the merge commit, and the original fork
+   PR will be closed.
+
+## Local development
+
+See the README for setup. The short version:
+
+```bash
+npm install
+npm run dev   # http://localhost:3000
+```
+
+Run the test suite before pushing:
+
+```bash
+npm test
+npm run lint
+npm run build
+```
+
+## Commit conventions
+
+[Conventional Commits](https://www.conventionalcommits.org/). Examples:
+
+- `feat(nominations): add gamedb_id backfill job`
+- `fix(auth): tighten signup throttle`
+- `docs(security): note fork-PR limitation`
+
+The `tech-writer-review` workflow auto-maintains user-facing docs, so a
+"missing CHANGELOG entry" review note is normal — let it land its own commit.


### PR DESCRIPTION
Closes part of the gameclub fork-PR safety audit.

## Audit summary

All workflows are **safe** for fork PRs (no security holes):
- `auto-approve-bots` and `auto-ready-copilot-prs` use `pull_request_target` but allowlist bot authors and never check out fork code.
- `auto-merge` uses `workflow_run` (can't be triggered by fork code unilaterally).
- `auto-assign-copilot` is issues-only.
- `update-pr-branches` is push-to-main only.
- `agent-review`, `devops-review`, `security-review` use `pull_request` (read-only token on forks) and fetch the diff via API rather than executing fork code.
- `tech-writer` uses `pull_request` and explicitly documents this in its header comment.

## What's broken (UX, not security)

All four required `*-review` checks need write API access to publish reviews + check-runs. On fork PRs they 403 → check is required but never passes → **fork PRs are unmergeable**.

## This PR

Documents the limitation in CONTRIBUTING.md and provides two workarounds (open an issue + get a feature branch, or accept a cherry-pick). Future end-to-end fix tracked in #73.