### PR TITLE
ci: let tech-writer pass for Dependabot and fork PRs without AUTOMATION_PAT

### DIFF
--- a/.github/workflows/tech-writer.yml
+++ b/.github/workflows/tech-writer.yml
@@ -48,22 +48,35 @@ jobs:
       TW_BOT_NAME: game-club tech-writer
       MAX_DIFF_BYTES: '25000'    # ~25 KB cap to stay under GitHub Models 8K-token input budget
     steps:
-      - name: Verify AUTOMATION_PAT is configured
+      - name: Detect tech-writer capability
+        id: cap
         env:
           PAT: ${{ secrets.AUTOMATION_PAT }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          BASE_REPO: ${{ github.event.pull_request.base.repo.full_name }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
         run: |
-          if [ -z "$PAT" ]; then
-            echo "::error::AUTOMATION_PAT secret missing. GITHUB_TOKEN-pushed commits do not retrigger CI; required for tech-writer."
+          set -euo pipefail
+          if [ -n "${PAT:-}" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+            echo "tech-writer enabled (AUTOMATION_PAT present)."
+          elif [ "$HEAD_REPO" != "$BASE_REPO" ] || [ "$PR_AUTHOR" = "dependabot[bot]" ]; then
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::AUTOMATION_PAT unavailable in this context (fork or Dependabot PR). Skipping tech-writer doc audit and passing the required check."
+          else
+            echo "::error::AUTOMATION_PAT secret is missing on a trusted PR. Configure the AUTOMATION_PAT repo secret so tech-writer can push doc updates."
             exit 1
           fi
 
       - uses: actions/checkout@v6
+        if: steps.cap.outputs.enabled == 'true'
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
           token: ${{ secrets.AUTOMATION_PAT }}
 
       - name: Mark check-run in_progress
+        if: steps.cap.outputs.enabled == 'true'
         run: |
           set -euo pipefail
           gh api "repos/${GITHUB_REPOSITORY}/check-runs" -X POST \
@@ -75,6 +88,7 @@ jobs:
 
       - name: Collect PR context
         id: ctx
+        if: steps.cap.outputs.enabled == 'true'
         run: |
           set -euo pipefail
           gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files" --paginate --jq '.[].filename' > /tmp/tw-files.txt
@@ -95,6 +109,7 @@ jobs:
           echo "files=$(wc -l < /tmp/tw-files.txt)" >> "$GITHUB_OUTPUT"
 
       - name: Build LLM request
+        if: steps.cap.outputs.enabled == 'true'
         run: |
           set -euo pipefail
           # All inputs read from files via jq --rawfile so no shell interpolation
@@ -123,6 +138,7 @@ jobs:
 
       - name: Call LLM
         id: llm
+        if: steps.cap.outputs.enabled == 'true'
         run: |
           set -euo pipefail
           # Belt-and-suspenders: if the assembled request is too large for the
@@ -161,7 +177,7 @@ jobs:
           echo "Verdict=$verdict patches=$patch_count"
 
       - name: Apply doc patches (validated paths)
-        if: steps.llm.outputs.patch_count != '0'
+        if: steps.cap.outputs.enabled == 'true' && steps.llm.outputs.patch_count != '0'
         id: apply
         run: |
           set -euo pipefail
@@ -173,7 +189,7 @@ jobs:
           fi
 
       - name: Commit and push doc patches
-        if: steps.llm.outputs.patch_count != '0' && steps.apply.outputs.no-files-changed != 'true'
+        if: steps.cap.outputs.enabled == 'true' && steps.llm.outputs.patch_count != '0' && steps.apply.outputs.no-files-changed != 'true'
         env:
           PATCH_SUMMARY: ${{ steps.llm.outputs.verdict }}
         run: |
@@ -203,6 +219,7 @@ jobs:
           git push origin "HEAD:${HEAD_REF}"
 
       - name: Post PR review summary
+        if: steps.cap.outputs.enabled == 'true'
         env:
           VERDICT: ${{ steps.llm.outputs.verdict }}
           PATCH_COUNT: ${{ steps.llm.outputs.patch_count }}
@@ -222,7 +239,7 @@ jobs:
             -F body=@/tmp/tw-review-body.txt >/dev/null
 
       - name: Finalize check-run
-        if: always()
+        if: always() && steps.cap.outputs.enabled == 'true'
         env:
           VERDICT: ${{ steps.llm.outputs.verdict || 'APPROVE' }}
         run: |


### PR DESCRIPTION
## Problem

The `tech-writer` job's first step (`Verify AUTOMATION_PAT is configured`) hard-failed with `exit 1` whenever `secrets.AUTOMATION_PAT` was empty. Dependabot-triggered runs and fork PRs never receive Actions secrets, so the required `tech-writer-review` check could **never** pass for them — those PRs could only be merged with an admin override.

The PAT is only needed by the later steps that push LLM-generated doc commits, call the GitHub Models API, and post check-runs — none of which can run in the Dependabot/fork context anyway.

## Fix

Replace the hard-fail with a capability-detection step (`id: cap`) that:

- **Enables** tech-writer when `AUTOMATION_PAT` is present → unchanged behavior on trusted PRs.
- **Skips** (passing the required check) on fork or Dependabot PRs where the PAT is unavailable and the LLM/push steps can't run. Emits a `::notice::` explaining why.
- **Still hard-fails** on a trusted (same-repo, non-Dependabot) PR when the PAT is genuinely misconfigured.

Every subsequent step is gated on `steps.cap.outputs.enabled == 'true'` (existing conditions preserved and combined). When disabled, only the capability step runs and succeeds, so the job's overall conclusion is `success` and the required `tech-writer-review` job-level check passes — exactly how Build/Test already pass for Dependabot.

No other files, env vars, the system prompt, or `TW_BOT_NAME` were changed. YAML validated.

## Consulted

- `devops-engineer` per routing matrix (changes to `.github/workflows/`) — change scoped to CI gating logic only.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>